### PR TITLE
AntiSMASH 7.1.0.1 + nodejs

### DIFF
--- a/antismash/7.1.0.1/Dockerfile
+++ b/antismash/7.1.0.1/Dockerfile
@@ -34,6 +34,7 @@ RUN conda install -c bioconda -c conda-forge\
     'meme==4.11.2' \
     blast \
     prodigal \
+    nodejs \
     --yes --freeze-installed && conda clean -afy
 
 RUN PYTHONDONTWRITEBYTECODE=1 pip install --no-cache-dir 'nrpys>=0.1.1'


### PR DESCRIPTION
This modified version of the antiSMASH container was created to cater to the specific needs of the MGnify pipelines.

nodejs is used to convert the regions.js file of the AS results into a json one that a python script uses to create a gff file from.

This version of the container was pushed to the following tag quay.io/microbiome-informatics/antismash:7.1.0.1_2