### PR TITLE
Add new container for Owltools

### DIFF
--- a/owltools/Dockerfile
+++ b/owltools/Dockerfile
@@ -1,4 +1,6 @@
-FROM maven:3.9.9-eclipse-temurin-23-noble
+FROM mambaorg/micromamba:2.0.5
+
+USER root
 
 LABEL maintainer="Microbiome Informatics Team www.ebi.ac.uk/metagenomics"
 
@@ -6,10 +8,17 @@ LABEL version="1"
 LABEL software="owltools"
 LABEL software.version="2024-06-12"
 
-RUN apt install git
+COPY --chown=$MAMBA_USER:$MAMBA_USER env.yml /tmp/env.yml
 
-RUN git clone https://github.com/owlcollab/owltools.git && \
-    cd /owltools/OWLTools-Parent && \
-    mvn clean install
+RUN micromamba install -y -n base -f /tmp/env.yml \
+    && micromamba install -y -n base conda-forge::procps-ng \
+    && micromamba clean -a -y
 
-ENV PATH="$PATH:/owltools/OWLTools-Runner/target"
+RUN apt-get update \
+    && apt-get install -y wget
+
+RUN wget https://github.com/owlcollab/owltools/releases/download/2024-06-12/owltools
+
+RUN chmod +x owltools
+
+ENV PATH="$PATH:/tmp"

--- a/owltools/Dockerfile
+++ b/owltools/Dockerfile
@@ -14,8 +14,7 @@ RUN micromamba install -y -n base -f /tmp/env.yml \
     && micromamba install -y -n base conda-forge::procps-ng \
     && micromamba clean -a -y
 
-RUN apt-get update \
-    && apt-get install -y wget
+ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"
 
 RUN wget https://github.com/owlcollab/owltools/releases/download/2024-06-12/owltools
 

--- a/owltools/Dockerfile
+++ b/owltools/Dockerfile
@@ -1,0 +1,15 @@
+FROM maven:3.9.9-eclipse-temurin-23-noble
+
+LABEL maintainer="Microbiome Informatics Team www.ebi.ac.uk/metagenomics"
+
+LABEL version="1"
+LABEL software="owltools"
+LABEL software.version="2024-06-12"
+
+RUN apt install git
+
+RUN git clone https://github.com/owlcollab/owltools.git && \
+    cd /owltools/OWLTools-Parent && \
+    mvn clean install
+
+ENV PATH="$PATH:/owltools/OWLTools-Runner/target"

--- a/owltools/env.yml
+++ b/owltools/env.yml
@@ -1,0 +1,5 @@
+channels:
+- conda-forge
+- bioconda
+dependencies:
+  - openjdk=23.0.1

--- a/owltools/env.yml
+++ b/owltools/env.yml
@@ -3,3 +3,4 @@ channels:
 - bioconda
 dependencies:
   - openjdk=23.0.1
+  - wget


### PR DESCRIPTION
New container for [Owltools](https://github.com/owlcollab/owltools) that we'll need for the GO-slim subworkflow.

Built it on my mac using `--platform linux/amd64` - I think that's correct for our case?