### PR TITLE
Docker file for mgnify-pipelines-toolkit/1.4.19

### DIFF
--- a/mgnify-pipelines-toolkit/1.4.19/Dockerfile
+++ b/mgnify-pipelines-toolkit/1.4.19/Dockerfile
@@ -1,0 +1,15 @@
+FROM mambaorg/micromamba:2.5.0
+
+COPY --chown=$MAMBA_USER:$MAMBA_USER env.yaml /tmp/env.yaml
+
+RUN micromamba install -y -n base -f /tmp/env.yaml \
+    && micromamba install -y -n base conda-forge::procps-ng \
+    && micromamba env export --name base --explicit > environment.lock \
+    && echo ">> CONDA_LOCK_START" \
+    && cat environment.lock \
+    && echo "<< CONDA_LOCK_END" \
+    && micromamba clean -a -y
+
+USER root
+
+ENV PATH="$MAMBA_ROOT_PREFIX/bin:$PATH"

--- a/mgnify-pipelines-toolkit/1.4.19/env.yaml
+++ b/mgnify-pipelines-toolkit/1.4.19/env.yaml
@@ -1,0 +1,9 @@
+channels:
+- conda-forge
+- bioconda
+dependencies:
+- pyfastx=2.2.0
+- python=3.12
+- pip
+- pip:
+  - mgnify-pipelines-toolkit==1.4.19


### PR DESCRIPTION
This image was created to solve the bcbio dependency missing in the bioconda recipe 